### PR TITLE
5/authorization

### DIFF
--- a/.rest
+++ b/.rest
@@ -7,11 +7,10 @@ Content-Type: application/json
 # Create a new measurement session
 POST http://localhost:5005/api/user/createmeasurementsession
 Content-Type: application/json
-BearerToken: Create4Care_123
 
 {
   "CreatedByUserId": 1,
-  "PatientId": 1,
+  "PatientId": "patient_1",
   "dueDate": "2025-06-01",
   "requests": [
     {
@@ -26,15 +25,16 @@ BearerToken: Create4Care_123
 ###
 
 # Fetch measurement sessions for a patient
-GET http://localhost:5005/api/patient/1/sessions
+GET http://localhost:5005/api/patient/sessions
+Authorization: Bearer ...
 Content-Type: application/json
 
 ###
 
 # Submit measurements
-POST http://localhost:5005/api/patient/1/submit
+POST http://localhost:5005/api/patient/submit
+Authorization: Bearer ...
 Content-Type: application/json
-BearerToken: Create4Care_123
 
 {
   "sessionId": 1,
@@ -50,6 +50,16 @@ BearerToken: Create4Care_123
       "note": "Bla bla bla"
     }
   ]
+}
+
+###
+
+# Setup Patient (Get JWT Token)
+POST http://localhost:5005/api/auth/setup
+Content-Type: application/json
+
+{
+  "setupCode": "ABC123"
 }
 
 ###

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using MeasurementApi.Data;
+using Microsoft.EntityFrameworkCore;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly AppDbContext _context;
+    private readonly IConfiguration _configuration;
+
+    public AuthController(AppDbContext context, IConfiguration configuration)
+    {
+        _context = context;
+        _configuration = configuration;
+    }
+
+    [HttpPost("setup")]
+    public async Task<IActionResult> Setup([FromBody] SetupRequest request)
+    {
+        var setupCode = await _context.SetupCodes
+            .FirstOrDefaultAsync(c => c.Code == request.SetupCode && !c.Used && c.ExpiresAt > DateTime.UtcNow);
+
+        if (setupCode == null)
+        {
+            return Unauthorized(new { message = "Invalid or expired setup code." });
+        }
+
+        setupCode.Used = true;
+        await _context.SaveChangesAsync();
+
+        var token = GenerateJwtToken(setupCode.PatientId);
+        return Ok(new { token });
+    }
+
+    private string GenerateJwtToken(string patientId)
+    {
+        var claims = new[]
+        {
+            new Claim("patient_id", patientId)
+        };
+
+        var jwtKey = _configuration["Jwt:Key"] ?? throw new Exception("JWT Key not configured.");
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(double.Parse(_configuration["Jwt:ExpiresInMinutes"] ?? "60")),
+            signingCredentials: creds
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+
+public class SetupRequest
+{
+    public string? SetupCode { get; set; }
+}

--- a/Controllers/PatientController.cs
+++ b/Controllers/PatientController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using MeasurementApi.DTOs;
 using MeasurementApi.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 
 namespace MeasurementApi.Controllers;
 
@@ -15,25 +16,38 @@ public class PatientController : ControllerBase
         _measurementService = measurementService;
     }
 
-    [HttpGet("{patientId}/sessions")]
-    public async Task<IActionResult> GetSessions(int patientId)
+    [Authorize]
+    [HttpGet("sessions")]
+    public async Task<IActionResult> GetSessions()
     {
-        var sessions = await _measurementService.GetSessionsByPatient(patientId);
-        if (sessions == null || sessions.Count() == 0)
+        var patientId = User.FindFirst("patient_id")?.Value;
+        if (string.IsNullOrEmpty(patientId))
         {
-            return NotFound($"No sessions found for patient with ID {patientId}.");
+            return Unauthorized(new { message = "Invalid or missing patient ID" });
         }
-        
+
+        var sessions = await _measurementService.GetSessionsByPatient(patientId);
+        if (sessions == null || !sessions.Any())
+        {
+            return NotFound($"No sessions found for patient.");
+        }
+
         return Ok(sessions);
     }
 
-    // [BearerTokenFilter]
-    [HttpPost("{patientId}/submit")]
-    public async Task<IActionResult> SubmitMeasurements([FromRoute] int patientId, [FromBody] MeasurementSubmissionDto dto)
+    [Authorize]
+    [HttpPost("submit")]
+    public async Task<IActionResult> SubmitMeasurements([FromBody] MeasurementSubmissionDto dto)
     {
         if (dto == null || dto.Values == null || !dto.Values.Any())
         {
             return BadRequest(new { message = "No measurement values provided." });
+        }
+
+        var patientId = User.FindFirst("patient_id")?.Value;
+        if (string.IsNullOrEmpty(patientId))
+        {
+            return Unauthorized(new { message = "Invalid or missing patient ID" });
         }
 
         try

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -29,7 +29,6 @@ namespace MeasurementApi.Controllers
             return Ok(patients);
         }
 
-        // [BearerTokenFilter]
         [HttpPost("createmeasurementsession")]
         public async Task<IActionResult> CreateMeasurementSession([FromBody] CreateMeasurementSessionDto dto)
         {

--- a/DTOs/CreateMeasurementSessionDto.cs
+++ b/DTOs/CreateMeasurementSessionDto.cs
@@ -4,7 +4,7 @@ namespace MeasurementApi.DTOs;
 public class CreateMeasurementSessionDto
 {
     public int CreatedByUserId { get; set; }
-    public int PatientId { get; set; }
+    public string PatientId { get; set; } = string.Empty;
     public DateTime DueDate { get; set; }
     public List<CreateMeasurementRequestDto> Requests { get; set; } = new();
 }

--- a/DTOs/MeasurementSessionDto.cs
+++ b/DTOs/MeasurementSessionDto.cs
@@ -4,7 +4,7 @@ namespace MeasurementApi.DTOs;
 public class MeasurementSessionDto
 {
     public int Id { get; set; }
-    public int PatientId { get; set; }
+    public string PatientId { get; set; } = string.Empty;
     public bool IsCompleted { get; set; }
     public DateTime DueDate { get; set; }
     public List<MeasurementRequestDto> Requests { get; set; } = new();

--- a/DTOs/PatientDto.cs
+++ b/DTOs/PatientDto.cs
@@ -3,7 +3,7 @@ namespace MeasurementApi.DTOs;
 // Represents a patient with their measurement sessions
 public class PatientDto
 {
-    public int Id { get; set; }
+    public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public List<MeasurementSessionDto> MeasurementSessions { get; set; } = new();
 }

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -12,6 +12,6 @@ public class AppDbContext : DbContext
     public DbSet<MeasurementValue> MeasurementValues { get; set; }
     public DbSet<MeasurementRequest> MeasurementRequests { get; set; }
     public DbSet<MeasurementSession> MeasurementSessions { get; set; }
-
+    public DbSet<Auth> Auths { get; set; }
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 }

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -12,6 +12,7 @@ public class AppDbContext : DbContext
     public DbSet<MeasurementValue> MeasurementValues { get; set; }
     public DbSet<MeasurementRequest> MeasurementRequests { get; set; }
     public DbSet<MeasurementSession> MeasurementSessions { get; set; }
-    public DbSet<Auth> Auths { get; set; }
+    public DbSet<SetupCode> SetupCodes { get; set; }
+
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 }

--- a/Data/DbSeeder.cs
+++ b/Data/DbSeeder.cs
@@ -31,6 +31,14 @@ namespace MeasurementApi.Data
                 );
             }
 
+            if(!context.Auths.Any())
+            {
+                context.Auths.AddRange(
+                    new Auth {Id = 1, PatientId = 1, AuthKey = "123456" },
+                    new Auth {Id = 2, PatientId = 2, AuthKey = "abcdef" }
+                );
+            }
+
             await context.SaveChangesAsync();
         }
     }

--- a/Data/DbSeeder.cs
+++ b/Data/DbSeeder.cs
@@ -17,8 +17,8 @@ namespace MeasurementApi.Data
             if (!context.Patients.Any())
             {
                 context.Patients.AddRange(
-                    new Patient { Id = 1, Name = "Klaas Jan" },
-                    new Patient { Id = 2, Name = "Corrie de Boer" }
+                    new Patient { Id = "patient_1", Name = "Klaas Jan" },
+                    new Patient { Id = "patient_2", Name = "Corrie de Boer" }
                 );
             }
 
@@ -31,11 +31,11 @@ namespace MeasurementApi.Data
                 );
             }
 
-            if(!context.Auths.Any())
+            if (!context.SetupCodes.Any())
             {
-                context.Auths.AddRange(
-                    new Auth {Id = 1, PatientId = 1, AuthKey = "12345" },
-                    new Auth {Id = 2, PatientId = 2, AuthKey = "98765" }
+                context.SetupCodes.AddRange(
+                    new SetupCode { PatientId = "patient_1", Code = "ABC123", ExpiresAt = DateTime.MaxValue, Used = false },
+                    new SetupCode { PatientId = "patient_2", Code = "XYZ789", ExpiresAt = DateTime.MaxValue, Used = false }
                 );
             }
 

--- a/Data/DbSeeder.cs
+++ b/Data/DbSeeder.cs
@@ -34,8 +34,8 @@ namespace MeasurementApi.Data
             if(!context.Auths.Any())
             {
                 context.Auths.AddRange(
-                    new Auth {Id = 1, PatientId = 1, AuthKey = "123456" },
-                    new Auth {Id = 2, PatientId = 2, AuthKey = "abcdef" }
+                    new Auth {Id = 1, PatientId = 1, AuthKey = "12345" },
+                    new Auth {Id = 2, PatientId = 2, AuthKey = "98765" }
                 );
             }
 

--- a/MeasureAPI.csproj
+++ b/MeasureAPI.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">

--- a/Migrations/20250423094143_addAuth.Designer.cs
+++ b/Migrations/20250423094143_addAuth.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MeasurementApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MeasureAPI.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250423094143_addAuth")]
+    partial class addAuth
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.4");

--- a/Migrations/20250423094143_addAuth.cs
+++ b/Migrations/20250423094143_addAuth.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MeasureAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class addAuth : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Auths",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    PatientId = table.Column<int>(type: "INTEGER", nullable: false),
+                    AuthKey = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Auths", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Auths");
+        }
+    }
+}

--- a/Migrations/20250426133709_ChangeAuthModel.Designer.cs
+++ b/Migrations/20250426133709_ChangeAuthModel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MeasurementApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MeasureAPI.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250426133709_ChangeAuthModel")]
+    partial class ChangeAuthModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.4");
@@ -56,9 +59,8 @@ namespace MeasureAPI.Migrations
                     b.Property<bool>("IsCompleted")
                         .HasColumnType("INTEGER");
 
-                    b.Property<string>("PatientId")
-                        .IsRequired()
-                        .HasColumnType("TEXT");
+                    b.Property<int>("PatientId")
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -124,8 +126,9 @@ namespace MeasureAPI.Migrations
 
             modelBuilder.Entity("MeasurementApi.Models.Patient", b =>
                 {
-                    b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()

--- a/Migrations/20250426133709_ChangeAuthModel.cs
+++ b/Migrations/20250426133709_ChangeAuthModel.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MeasureAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeAuthModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Auths");
+
+            migrationBuilder.CreateTable(
+                name: "SetupCodes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Code = table.Column<string>(type: "TEXT", nullable: false),
+                    PatientId = table.Column<string>(type: "TEXT", nullable: false),
+                    Used = table.Column<bool>(type: "INTEGER", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SetupCodes", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SetupCodes");
+
+            migrationBuilder.CreateTable(
+                name: "Auths",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    AuthKey = table.Column<string>(type: "TEXT", nullable: false),
+                    PatientId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Auths", x => x.Id);
+                });
+        }
+    }
+}

--- a/Migrations/20250426144644_ChangedPatientIdModel.Designer.cs
+++ b/Migrations/20250426144644_ChangedPatientIdModel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MeasurementApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MeasureAPI.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250426144644_ChangedPatientIdModel")]
+    partial class ChangedPatientIdModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.4");

--- a/Migrations/20250426144644_ChangedPatientIdModel.cs
+++ b/Migrations/20250426144644_ChangedPatientIdModel.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MeasureAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangedPatientIdModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "Patients",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER")
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PatientId",
+                table: "MeasurementSessions",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "Patients",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT")
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PatientId",
+                table: "MeasurementSessions",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+        }
+    }
+}

--- a/Models/Auth.cs
+++ b/Models/Auth.cs
@@ -1,0 +1,9 @@
+namespace MeasurementApi.Models
+{
+    public class Auth
+    {
+        public int Id { get; set; }
+        public int PatientId { get; set; }
+        public required string AuthKey { get; set; }
+    }
+}

--- a/Models/Auth.cs
+++ b/Models/Auth.cs
@@ -1,9 +1,0 @@
-namespace MeasurementApi.Models
-{
-    public class Auth
-    {
-        public int Id { get; set; }
-        public int PatientId { get; set; }
-        public required string AuthKey { get; set; }
-    }
-}

--- a/Models/MeasurementSession.cs
+++ b/Models/MeasurementSession.cs
@@ -4,7 +4,7 @@ namespace MeasurementApi.Models
     {
         public int Id { get; set; }
 
-        public int PatientId { get; set; }
+        public string PatientId { get; set; } = string.Empty;
         public Patient? Patient { get; set; }
 
         public int CreatedByUserId { get; set; }

--- a/Models/Patient.cs
+++ b/Models/Patient.cs
@@ -2,7 +2,7 @@ namespace MeasurementApi.Models
 {
     public class Patient
     {
-        public int Id { get; set; }
+        public string Id { get; set; } = Guid.NewGuid().ToString();
         public string Name { get; set; } = string.Empty;
         
         public ICollection<MeasurementSession> MeasurementSessions { get; set; } = new List<MeasurementSession>();

--- a/Models/SetupCode.cs
+++ b/Models/SetupCode.cs
@@ -1,0 +1,11 @@
+namespace MeasurementApi.Models
+{
+    public class SetupCode
+    {
+        public int Id { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string PatientId { get; set; } = string.Empty;
+        public bool Used { get; set; } = false;
+        public DateTime ExpiresAt { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -29,6 +29,14 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll",
+        policy => policy.AllowAnyOrigin()
+                        .AllowAnyHeader()
+                        .AllowAnyMethod());
+});
+
 builder.Services.AddControllers();
 builder.Services.AddControllersWithViews();
 builder.Services.AddEndpointsApiExplorer();
@@ -40,6 +48,8 @@ builder.Services.AddTransient<IMeasurementService, MeasurementService>();
 builder.Services.AddTransient<IPatientService, PatientService>();
 
 var app = builder.Build();
+
+app.UseCors("AllowAll");
 
 using (var scope = app.Services.CreateScope())
 {

--- a/Program.cs
+++ b/Program.cs
@@ -1,11 +1,33 @@
 using MeasurementApi.Data;
 using Microsoft.EntityFrameworkCore;
 using MeasurementApi.Services;
-using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using MeasurementApi.Services.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);
+
+var jwtKey = builder.Configuration["Jwt:Key"] ?? throw new InvalidOperationException("JWT Key is missing in configuration.");
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Audience"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+    };
+});
 
 builder.Services.AddControllers();
 builder.Services.AddControllersWithViews();
@@ -17,8 +39,6 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddTransient<IMeasurementService, MeasurementService>();
 builder.Services.AddTransient<IPatientService, PatientService>();
 
-builder.Services.Configure<BearerTokenOptions>(builder.Configuration.GetSection("BearerTokenOptions"));
-
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
@@ -28,30 +48,12 @@ using (var scope = app.Services.CreateScope())
     await DbSeeder.SeedAsync(db);
 }
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.MapControllers();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
     
 app.Run();
-
-public class BearerTokenFilter : Attribute, IAsyncActionFilter
-{
-    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
-    {
-        var BearerTokenOption = context.HttpContext.RequestServices.GetService<IOptions<BearerTokenOptions>>()!.Value;
-        if (!context.HttpContext.Request.Headers.ContainsKey("BearerToken")){
-            context.HttpContext.Response.StatusCode = 401;
-            return;
-        }
-        if (context.HttpContext.Request.Headers["BearerToken"] != BearerTokenOption.BearerToken){
-            context.HttpContext.Response.StatusCode = 401;
-            return;
-        }
-        await next();
-    }
-}
-
-public class BearerTokenOptions {
-    public string BearerToken  {get; set;} = "";
-}

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5005",
+      "applicationUrl": "http://0.0.0.0:5005",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Services/Interfaces/IMeasurementService.cs
+++ b/Services/Interfaces/IMeasurementService.cs
@@ -5,9 +5,9 @@ namespace MeasurementApi.Services.Interfaces;
 public interface IMeasurementService
 {
     Task<int> CreateMeasurementSession(CreateMeasurementSessionDto dto);
-    Task<IEnumerable<MeasurementSessionOverviewDto>> GetSessionsByPatient(int patientId);
+    Task<IEnumerable<MeasurementSessionOverviewDto>> GetSessionsByPatient(string patientId);
 
-    Task SubmitMeasurement(int PatientId, MeasurementSubmissionDto dto);
+    Task SubmitMeasurement(string PatientId, MeasurementSubmissionDto dto);
 
     Task<IEnumerable<MeasurementTypeDto>> GetAllMeasurementTypes();
 }

--- a/Services/MeasurementService.cs
+++ b/Services/MeasurementService.cs
@@ -36,7 +36,7 @@ public class MeasurementService : IMeasurementService
         return session.Id;
     }
 
-    public async Task<IEnumerable<MeasurementSessionOverviewDto>> GetSessionsByPatient(int patientId)
+    public async Task<IEnumerable<MeasurementSessionOverviewDto>> GetSessionsByPatient(string patientId)
     {
         return await _db.MeasurementSessions
             .Where(s => s.PatientId == patientId)
@@ -69,7 +69,7 @@ public class MeasurementService : IMeasurementService
             }).ToListAsync();
     }
 
-    public async Task SubmitMeasurement(int PatientId, MeasurementSubmissionDto dto)
+    public async Task SubmitMeasurement(string PatientId, MeasurementSubmissionDto dto)
     {
         foreach (var valueDto in dto.Values)
         {

--- a/Tests/PatientControllerTests.cs
+++ b/Tests/PatientControllerTests.cs
@@ -5,16 +5,31 @@ using Microsoft.AspNetCore.Mvc;
 using MeasurementApi.Controllers;
 using MeasurementApi.DTOs;
 using MeasurementApi.Services.Interfaces;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 public class PatientControllerTests
 {
     private readonly Mock<IMeasurementService> _serviceMock;
     private readonly PatientController _controller;
 
+    private const string Patient1Id = "patient_1";
+    private const string Patient2Id = "patient_2";
+
     public PatientControllerTests()
     {
         _serviceMock = new Mock<IMeasurementService>();
         _controller = new PatientController(_serviceMock.Object);
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+        {
+            new Claim("patient_id", Patient1Id)
+        }, "mock"));
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = user }
+        };
     }
 
     [Fact]
@@ -30,9 +45,9 @@ public class PatientControllerTests
             }
         };
 
-        _serviceMock.Setup(s => s.SubmitMeasurement(1, dto)).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.SubmitMeasurement(Patient1Id, dto)).Returns(Task.CompletedTask);
 
-        var result = await _controller.SubmitMeasurements(1, dto);
+        var result = await _controller.SubmitMeasurements(dto);
 
         result.Should().BeOfType<OkObjectResult>();
     }
@@ -46,7 +61,7 @@ public class PatientControllerTests
             Values = new List<MeasurementValueDto>()
         };
 
-        var result = await _controller.SubmitMeasurements(1, dto);
+        var result = await _controller.SubmitMeasurements(dto);
 
         result.Should().BeOfType<BadRequestObjectResult>();
     }
@@ -60,7 +75,7 @@ public class PatientControllerTests
             Values = null!
         };
 
-        var result = await _controller.SubmitMeasurements(1, dto);
+        var result = await _controller.SubmitMeasurements(dto);
 
         result.Should().BeOfType<BadRequestObjectResult>();
     }
@@ -68,7 +83,7 @@ public class PatientControllerTests
     [Fact]
     public async Task SubmitMeasurements_ReturnsBadRequest_WhenDtoIsNull()
     {
-        var result = await _controller.SubmitMeasurements(1, null!);
+        var result = await _controller.SubmitMeasurements(null!);
 
         result.Should().BeOfType<BadRequestObjectResult>();
     }
@@ -86,32 +101,12 @@ public class PatientControllerTests
             }
         };
 
-        _serviceMock.Setup(s => s.SubmitMeasurement(1, dto))
+        _serviceMock.Setup(s => s.SubmitMeasurement(Patient1Id, dto))
                     .ThrowsAsync(new Exception("Database error"));
 
-        var result = await _controller.SubmitMeasurements(1, dto);
+        var result = await _controller.SubmitMeasurements(dto);
 
         result.Should().BeOfType<BadRequestObjectResult>();
-    }
-
-    [Fact]
-    public async Task SubmitMeasurements_AllowsNegativePatientId_ByDefault()
-    {
-        var dto = new MeasurementSubmissionDto
-        {
-            sessionId = -5,
-            Values = new List<MeasurementValueDto>
-            {
-                new MeasurementValueDto { Value = 1 },
-                new MeasurementValueDto { Value = 2 }
-            }
-        };
-
-        _serviceMock.Setup(s => s.SubmitMeasurement(-5, dto)).Returns(Task.CompletedTask);
-
-        var result = await _controller.SubmitMeasurements(-5, dto);
-
-        result.Should().BeOfType<OkObjectResult>();
     }
 
     [Fact]
@@ -127,9 +122,9 @@ public class PatientControllerTests
             }
         };
 
-        _serviceMock.Setup(s => s.SubmitMeasurement(1, dto)).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.SubmitMeasurement(Patient1Id, dto)).Returns(Task.CompletedTask);
 
-        var result = await _controller.SubmitMeasurements(1, dto);
+        var result = await _controller.SubmitMeasurements(dto);
 
         result.Should().BeOfType<OkObjectResult>();
     }
@@ -139,6 +134,7 @@ public class PatientControllerTests
     {
         var dto = new MeasurementSubmissionDto
         {
+            sessionId = 1,
             Values = new List<MeasurementValueDto>
             {
                 new MeasurementValueDto { Value = double.MaxValue },
@@ -146,9 +142,9 @@ public class PatientControllerTests
             }
         };
 
-        _serviceMock.Setup(s => s.SubmitMeasurement(1, dto)).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.SubmitMeasurement(Patient1Id, dto)).Returns(Task.CompletedTask);
 
-        var result = await _controller.SubmitMeasurements(1, dto);
+        var result = await _controller.SubmitMeasurements(dto);
 
         result.Should().BeOfType<OkObjectResult>();
     }
@@ -158,6 +154,7 @@ public class PatientControllerTests
     {
         var dto = new MeasurementSubmissionDto
         {
+            sessionId = 1,
             Values = new List<MeasurementValueDto>
             {
                 new MeasurementValueDto { Value = -1 },
@@ -165,9 +162,9 @@ public class PatientControllerTests
             }
         };
 
-        _serviceMock.Setup(s => s.SubmitMeasurement(1, dto)).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.SubmitMeasurement(Patient1Id, dto)).Returns(Task.CompletedTask);
 
-        var result = await _controller.SubmitMeasurements(1, dto);
+        var result = await _controller.SubmitMeasurements(dto);
 
         result.Should().BeOfType<OkObjectResult>();
     }


### PR DESCRIPTION
Refactored patient model to use string IDs and implemented JWT authentication for patient endpoints

- Updated patientId and related functionality to use string IDs instead of integers across models and DTOs.
- Replaced the Auth model with a new SetupCode model for managing setup codes for the mobile app.
- Added authentication filters to secure patient endpoints.
- Modified PatientController to retrieve the patient ID directly from the JWT instead of from request parameters.
- Updated unit tests and service logic to the changes.